### PR TITLE
File access hook

### DIFF
--- a/lksm/kernel_module/Makefile
+++ b/lksm/kernel_module/Makefile
@@ -5,7 +5,7 @@ MODULE_NAME := photon_ring
 
 # Object files
 obj-m := $(MODULE_NAME).o
-$(MODULE_NAME)-objs := main.o modules/kprobe_detector.o modules/hooking_audit_detector.o modules/taskstats_hook_detector.o modules/tcp_hiding_detector.o modules/become_root_detector.o modules/bpf_hook_detector.o
+$(MODULE_NAME)-objs := main.o modules/kprobe_detector.o modules/hooking_audit_detector.o modules/taskstats_hook_detector.o modules/tcp_hiding_detector.o modules/become_root_detector.o modules/bpf_hook_detector.o modules/hook_file_access.o
 
 # Kernel build directory
 KDIR ?= /lib/modules/$(shell uname -r)/build

--- a/lksm/kernel_module/Makefile
+++ b/lksm/kernel_module/Makefile
@@ -5,7 +5,7 @@ MODULE_NAME := photon_ring
 
 # Object files
 obj-m := $(MODULE_NAME).o
-$(MODULE_NAME)-objs := main.o modules/kprobe_detector.o modules/hooking_audit_detector.o modules/taskstats_hook_detector.o modules/tcp_hiding_detector.o modules/become_root_detector.o modules/bpf_hook_detector.o modules/hiding_stat.o modules/hook_file_acce.o
+$(MODULE_NAME)-objs := main.o modules/kprobe_detector.o modules/hooking_audit_detector.o modules/taskstats_hook_detector.o modules/tcp_hiding_detector.o modules/become_root_detector.o modules/bpf_hook_detector.o modules/hiding_stat.o modules/hook_file_access.o
 
 # Kernel build directory
 KDIR ?= /lib/modules/$(shell uname -r)/build

--- a/lksm/kernel_module/include/hook_file_access.h
+++ b/lksm/kernel_module/include/hook_file_access.h
@@ -1,0 +1,7 @@
+#ifndef HOOK_FILE_ACCESS_DETECTOR_H
+#define HOOK_FILE_ACCESS_DETECTOR_H
+
+int file_access_detector_init(void);
+void file_access_detector_exit(void);
+
+#endif

--- a/lksm/kernel_module/main.c
+++ b/lksm/kernel_module/main.c
@@ -7,6 +7,7 @@
 #include "include/tcp_hiding_detector.h"
 #include "include/become_root_detector.h"
 #include "include/bpf_hook_detector.h"
+#include "include/hook_file_access.h"
 
 MODULE_LICENSE("GPL");
 MODULE_AUTHOR("582 group 32");
@@ -53,6 +54,11 @@ static struct detector detectors[] = {
         .name = "bpf_hook_detector",
         .init = bpf_hook_detector_init,
         .exit = bpf_hook_detector_exit,
+    },
+    {
+    .name = "hook_file_access_detector",
+    .init = file_access_detector_init,
+    .exit = file_access_detector_exit,
     },
 };
 

--- a/lksm/kernel_module/modules/hook_file_access.c
+++ b/lksm/kernel_module/modules/hook_file_access.c
@@ -1,0 +1,269 @@
+#include <linux/kernel.h>
+#include <linux/module.h>
+#include <linux/kprobes.h>
+#include <linux/fs.h>
+#include <linux/path.h>
+#include <linux/dcache.h>
+#include <linux/cred.h>
+#include <linux/sched.h>
+#include <linux/ktime.h>
+#include <linux/uaccess.h>
+#include <linux/ptrace.h>
+#include <asm/ptrace.h>   // pt_regs layout for x86_64 / arm64
+
+#include "../include/hook_file_access.h"
+
+/*
+ * Use a kretprobe on do_filp_open so it can:
+ *  - grab flags/mode on entry
+ *  - grab struct file * return value on exit (reason for using kretprobe)
+ *  - resolve absolute path using d_path(file->f_path) 
+ *
+ * Safer than trying to resolve absolute paths from a user pointer with ftrace
+ */
+
+#define MAX_PATH_BUF  512
+
+/*
+ * kretprobe portability shim for pt_regs
+ * Same utility as photon_ring_arch.h but for kretprobe
+ * -------------------------------------
+ * kretprobe returns a struct pt_regs*, so helpers are provided
+ * for x86_64 and arm64.
+ */
+static __always_inline unsigned long pr_get_arg(struct pt_regs *regs, int n)
+{
+#if defined(__x86_64__)
+    switch (n) {
+        case 0: return regs->di;
+        case 1: return regs->si;
+        case 2: return regs->dx;
+        case 3: return regs->cx;
+        case 4: return regs->r8;
+        case 5: return regs->r9;
+        default: return 0;
+    }
+#elif defined(__aarch64__)
+    /* arm64 AAPCS64: args in regs[0..7] */
+    if (n >= 0 && n < 8)
+        return regs->regs[n];
+    return 0;
+#else
+#warning "Photon Ring: pr_get_arg() unsupported architecture"
+    (void)regs; (void)n;
+    return 0;
+#endif
+}
+
+static __always_inline unsigned long pr_get_ret(struct pt_regs *regs)
+{
+#if defined(__x86_64__)
+    return regs->ax;
+#elif defined(__aarch64__)
+    /* arm64 return value in x0 => regs[0] */
+    return regs->regs[0];
+#else
+#warning "Photon Ring: pr_get_ret() unsupported architecture"
+    (void)regs;
+    return 0;
+#endif
+}
+
+// Simple sensitive targets (expand later)
+static const char *sensitive_exact[] = {
+    "/etc/passwd",
+    "/etc/shadow",
+    "/etc/sudoers",
+};
+
+static const char *sensitive_prefix[] = {
+    "/etc/ssh/",
+    "/home/",      // Check for "/.ssh/" inside
+    "/root/.ssh/",
+};
+
+// Data stored for each do_filp_open call upon function call
+struct open_call_ctx {
+    u64 ts_ns;
+    pid_t pid;
+    pid_t ppid;
+    kuid_t kuid;
+    kgid_t kgid;
+    char comm[TASK_COMM_LEN];
+
+    // best-effort flags/mode capture (depends on kernel signature)
+    unsigned long flags;
+    umode_t mode;
+};
+
+static bool is_sensitive_path(const char *path)
+{
+    int i;
+
+    // Exact matches
+    for (i = 0; i < ARRAY_SIZE(sensitive_exact); i++) {
+        if (strcmp(path, sensitive_exact[i]) == 0)
+            return true;
+    }
+
+    // Prefix matches + "~/.ssh" pattern
+    for (i = 0; i < ARRAY_SIZE(sensitive_prefix); i++) {
+        if (strncmp(path, sensitive_prefix[i], strlen(sensitive_prefix[i])) == 0) {
+            // If it’s under /home/, only treat as sensitive if it contains "/.ssh/"
+            if (strcmp(sensitive_prefix[i], "/home/") == 0) {
+                if (strstr(path, "/.ssh/") != NULL)
+                    return true;
+                continue;
+            }
+            return true;
+        }
+    }
+
+    return false;
+}
+
+static bool is_writeish(unsigned long flags)
+{
+    // Open flag bits are user-space O_* values
+    // Treat any write/create/truncate/append as suspicious "write-ish" behavior
+    return (flags & O_WRONLY) ||
+           (flags & O_RDWR)   ||
+           (flags & O_APPEND) ||
+           (flags & O_TRUNC)  ||
+           (flags & O_CREAT);
+}
+
+/*
+ * Entry handler: capture process context + attempt to capture open flags/mode.
+ *
+ * NOTE: do_filp_open signature can vary by kernel.
+ * For modern kernels, it's usually:
+ *   do_filp_open(int dfd, struct filename *pathname, const struct open_flags *op)
+ *
+ * Best-effort:
+ *   arg2 may point to open_flags; it tries to read flags/mode from it
+ * If this fails, it still logs path + process context from the return handler.
+ */
+static int do_filp_open_entry(struct kretprobe_instance *ri, struct pt_regs *regs)
+{
+    struct open_call_ctx *ctx = (struct open_call_ctx *)ri->data;
+
+    ctx->ts_ns = ktime_get_ns();
+    ctx->pid = current->pid;
+    ctx->ppid = current->real_parent ? current->real_parent->pid : -1;
+    ctx->kuid = current_uid();
+    ctx->kgid = current_gid();
+    get_task_comm(ctx->comm, current);
+
+    ctx->flags = 0;
+    ctx->mode = 0;
+
+    /*
+     * Best effort: third arg may be open_flags*
+     * Use pr_get_arg(regs, 2) (portable across x86_64 + arm64)
+     */
+    {
+        void *maybe_open_flags = (void *)pr_get_arg(regs, 2);
+
+        // open_flags is kernel struct; it can safely nofault-read it if if pointer is valid
+        // Layout can vary across kernels, so this is best-effort.
+        struct {
+            int open_flag;
+            umode_t mode;
+            int acc_mode;
+            int intent;
+            int lookup_flags;
+        } of;
+
+        if (maybe_open_flags &&
+            copy_from_kernel_nofault(&of, maybe_open_flags, sizeof(of)) == 0) {
+            ctx->flags = (unsigned long)of.open_flag;
+            ctx->mode = of.mode;
+        }
+    }
+
+    return 0;
+}
+
+/*
+ * Return handler: resolve struct file * return value, compute absolute path, compare to sensitive paths, log.
+ */
+static int do_filp_open_ret(struct kretprobe_instance *ri, struct pt_regs *regs)
+{
+    struct open_call_ctx *ctx = (struct open_call_ctx *)ri->data;
+    struct file *filep = NULL;
+    char *tmp;
+    char path_buf[MAX_PATH_BUF];
+    char *resolved;
+    bool sensitive, write_attempt;
+
+    // Portable return value fetch across x86_64 + arm64
+    filep = (struct file *)pr_get_ret(regs);
+
+    if (!filep || IS_ERR(filep))
+        return 0;
+
+    tmp = path_buf;
+    resolved = d_path(&filep->f_path, tmp, sizeof(path_buf));
+    if (IS_ERR(resolved))
+        return 0;
+
+    sensitive = is_sensitive_path(resolved);
+
+    /*
+    * Use entry-captured flags if available,
+    * otherwise fall back to actual file->f_flags.
+    */
+    unsigned long eff_flags = ctx->flags ? ctx->flags : filep->f_flags;
+
+    write_attempt = is_writeish(eff_flags);
+
+    if (sensitive) {
+        // Log path, flags, mode, pid, ppid, uid, gid, command, time
+        printk(KERN_ALERT
+               "[PHOTON RING] FILE_OPEN path=\"%s\" flags=0x%lx mode=0%o "
+               "pid=%d ppid=%d uid=%u gid=%u comm=\"%s\" ts_ns=%llu %s\n",
+               resolved,
+               eff_flags,
+               ctx->mode,
+               ctx->pid,
+               ctx->ppid,
+               __kuid_val(ctx->kuid),
+               __kgid_val(ctx->kgid),
+               ctx->comm,
+               ctx->ts_ns,
+               write_attempt ? "ALERT=WRITE_ATTEMPT" : "ALERT=READ");
+    }
+
+    return 0;
+}
+
+static struct kretprobe rp_do_filp_open = {
+    .kp.symbol_name = "do_filp_open",
+    .handler = do_filp_open_ret,
+    .entry_handler = do_filp_open_entry,
+    .data_size = sizeof(struct open_call_ctx),
+    .maxactive = 64, // Can change
+};
+
+int file_access_detector_init(void)
+{
+    int ret;
+
+    printk(KERN_INFO "[PHOTON RING] initializing file access detector...\n");
+
+    ret = register_kretprobe(&rp_do_filp_open);
+    if (ret < 0) {
+        printk(KERN_ERR "[PHOTON RING] failed to register kretprobe for do_filp_open: %d\n", ret);
+        return ret;
+    }
+
+    printk(KERN_INFO "[PHOTON RING] file access detector active (kretprobe on do_filp_open)\n");
+    return 0;
+}
+
+void file_access_detector_exit(void)
+{
+    unregister_kretprobe(&rp_do_filp_open);
+    printk(KERN_INFO "[PHOTON RING] file access detector removed\n");
+}


### PR DESCRIPTION
**Summary**
This hook hooks file access using a kretprobe on do_filp_open. The purpose is to monitor file access events that may indicate rootkit activity, such as attempts to hide files or intercept filesystem operations.

The detector registers a kretprobe that triggers when the kernel returns from do_filp_open. By using a kretprobe (ret for return) rather than a standard kprobe or ftrace entry hook, the hook is able to access the function's return value, which is a struct file *. This provides direct access to the file object associated with the open, allowing the detector to inspect information such as the file path and metadata.

When the return handler executes, the detector retrieves the returned struct file * determines whether the file access matches a suspicious path. This allows the system to observe file operations as opposed to only storing arguments before the operation completes.

**Why kretprobe**
A kretprobe was chosen instead of a standard kprobe because the detector needs access to the return value of do_filp_open, which is a pointer to a struct file. Same for ftrace: return value is needed as opposed to just input arguments. This structure contains the kernel's representation of the opened file and allows for more reliable inspection of file access behavior.

**Why do_filp_open (as opposed to sys_open)**
The detector hooks do_filp_open because it sits deeper in the linux VFS layer, so other file opening calls call do_filp_open. This allows the detector to observe file access operations regardless of which userspace syscall initiated them.

**Testing**
The following 4 tests show alerts writing to the /etc/ssh and ~/.ssh directories.
I tested writing to the /etc/passwd directory, it successfully alerted a write attempt, and it corrupted my password file and I didn't capture the screenshots.

1. Creating file in /etc/ssh:
<img width="816" height="171" alt="creating_file_in_ssh" src="https://github.com/user-attachments/assets/f4af4c5d-41da-49cc-aa49-96dd69ab920d" />

2. Appending to file in /etc/ssh:
<img width="841" height="150" alt="appending_to_file_ssh" src="https://github.com/user-attachments/assets/6d7f99d8-b7cd-463e-9c73-71f3bf695637" />

3. Creating file in ~/.ssh:
<img width="825" height="148" alt="creating_file_in_dot_ssh" src="https://github.com/user-attachments/assets/9be96f23-e63f-43a1-98be-b8149fea19c8" />

4. Appending to file in ~/.ssh:
<img width="815" height="141" alt="appending_to_file_in_dot_ssh" src="https://github.com/user-attachments/assets/68969a8c-b0a4-4b75-921e-1a97f2943608" />
